### PR TITLE
dirty-fix to add width, height and hash to images on upload

### DIFF
--- a/src/services/controllers/LSP3Profile.ts
+++ b/src/services/controllers/LSP3Profile.ts
@@ -399,7 +399,15 @@ const uploadProfileData = async (
       if (path) {
         profileData = {
           ...profileData,
-          profileImage: [{ ...profileData.profileImage[0], url: path }],
+          profileImage: [
+            {
+              ...profileData.profileImage[0],
+              url: path,
+              hash: path.replace('ipfs://', ''),
+              width: '1',
+              height: '1',
+            },
+          ],
         };
       }
     });
@@ -409,7 +417,15 @@ const uploadProfileData = async (
       if (path) {
         profileData = {
           ...profileData,
-          backgroundImage: [{ ...profileData.backgroundImage[0], url: path }],
+          backgroundImage: [
+            {
+              ...profileData.backgroundImage[0],
+              url: path,
+              hash: path.replace('ipfs://', ''),
+              width: '1',
+              height: '1',
+            },
+          ],
         };
       }
     });

--- a/src/services/models.ts
+++ b/src/services/models.ts
@@ -118,12 +118,14 @@ export interface ISetProfileData {
     height: string;
     hashFunction: 'keccak256(bytes)';
     url: File | string;
+    hash?: string;
   }[];
   profileImage: {
     width: string;
     height: string;
     hashFunction: 'keccak256(bytes)';
     url: File | string;
+    hash?: string;
   }[];
   name: string;
   description: string;


### PR DESCRIPTION
dirty-fix to add width, height and hash to profile image and background image on upload to prevent errors while validating a profile.

While unpacking a card to a profile, the node-server validates the profile: https://github.com/fanzone-media/blockchain-node/blame/b4dbf55104779691232ea2e9f539721183146216/src/modules/cards/use%20cases/unpackCard/UnpackCard.ts#L35
```js
const profile = await this.profileRepo.getProfile(req.to);
```

The function `getProfile` will proceed to validate the profile image and background image, and eventually will end up calling the `create` function and will fail when calling `Guard.againstNullOrUndefinedBulk` because the upload form as it is now does not add width, height or hash when uploading an image.
https://github.com/fanzone-media/blockchain-node/blame/b4dbf55104779691232ea2e9f539721183146216/src/modules/profiles/domain/image.ts#L39-L59
```js
    public static create(props: ImageProps): Result<Image> {
        const guardResult = Guard.againstNullOrUndefinedBulk([
            { argument: props.width, argumentName: 'width' },
            { argument: props.height, argumentName: 'height' },
            { argument: props.hash, argumentName: 'hash' },
            { argument: props.hashFunction, argumentName: 'hashFunction' },
            { argument: props.url, argumentName: 'url' },
        ]);

        if (!guardResult.succeeded) {
            return Result.fail<Image>(guardResult.message);
        }

        const defaultValues: ImageProps = {
            ...props,
        };

        const ingredientType = new Image(defaultValues);

        return Result.ok<Image>(ingredientType);
    }
```